### PR TITLE
Google login function should broadcast access_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ There are total three directives for handling Google, Facebook, LinkedIn authent
 - `socialProvider.setLinkedInKey("YOUR LINKEDIN CLIENT ID")`
 - `socialProvider.setFbKey("YOUR FACEBOOK APP ID")`
 - `$rootScope.$on('event:social-sign-in-success', function(event, userDetails){})` 
-   Braodcast event which will be triggered after successful authentication. `userDetails` is an `Object` consists of `{name: <user_name>, email: <user_email>, imageUrl: <image_url>, uid: <UID by social vendor>, provider: <Google/Facebook/LinkedIN>, token: <Google ID token (only for google)>}` 
+   Braodcast event which will be triggered after successful authentication. `userDetails` is an `Object` consists of `{name: <user_name>, email: <user_email>, imageUrl: <image_url>, uid: <UID by social vendor>, provider: <Google/Facebook/LinkedIN>, token: <Google ID token (only for google)>, access_token: <Google access token for server side call (only for google)>}` 
 - `socialLoginService.logout()`
    For logout
 - `$rootScope.$on('event:social-sign-out-success', function(event, logoutStatus){})`

--- a/angularjs-social-login.js
+++ b/angularjs-social-login.js
@@ -158,9 +158,10 @@ socialLogin.directive("gLogin", function($rootScope, social, socialLoginService)
 		    		scope.gauth = gapi.auth2.getAuthInstance();	
 	        	scope.gauth.signIn().then(function(googleUser){
 	        		var profile = googleUser.getBasicProfile();
+				var accessToken = googleUser.getAuthResponse().access_token
 	        		var idToken = googleUser.getAuthResponse().id_token
 	        		socialLoginService.setProvider("google");
-	        		$rootScope.$broadcast('event:social-sign-in-success', {token: idToken, name: profile.getName(), email: profile.getEmail(), uid: profile.getId(), provider: "google", imageUrl: profile.getImageUrl()});
+	        		$rootScope.$broadcast('event:social-sign-in-success', {token: idToken,accessToken:access_token, name: profile.getName(), email: profile.getEmail(), uid: profile.getId(), provider: "google", imageUrl: profile.getImageUrl()});
 	        	}, function(err){
 	        		console.log(err);
 	        	})


### PR DESCRIPTION
Google login function  will not return additional parameter access_token 
required by users trying to do the authentication and data fetching from server side  